### PR TITLE
Add relabeling setting to add label only to response count metric

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -489,6 +489,9 @@ namespace "app1" {
     from = "request"
     split = 2
 
+    // if enabled, only include label in response count metric (default is false)
+    only_counter = false
+
     match "^/users/[0-9]+" {
       replacement = "/users/:id"
     }

--- a/config/struct_relabel.go
+++ b/config/struct_relabel.go
@@ -13,6 +13,7 @@ type RelabelConfig struct {
 	Whitelist   []string            `hcl:"whitelist"`
 	Matches     []RelabelValueMatch `hcl:"match"`
 	Split       int                 `hcl:"split"`
+	OnlyCounter bool                `hcl:"only_counter" yaml:"only_counter"`
 
 	WhitelistExists bool
 	WhitelistMap    map[string]interface{}

--- a/example-config.hcl
+++ b/example-config.hcl
@@ -49,6 +49,8 @@ namespace "nginx" {
   relabel "user" {
     from = "remote_user"
     // whitelist = ["-", "user1", "user2"]
+
+    only_counter = true
   }
 
   relabel "request_uri" {

--- a/main.go
+++ b/main.go
@@ -87,14 +87,21 @@ func (m *Metrics) Init(cfg *config.NamespaceConfig) {
 	cfg.MustCompile()
 
 	labels := cfg.OrderedLabelNames
+	counterLabels := labels
 
 	for i := range cfg.RelabelConfigs {
-		labels = append(labels, cfg.RelabelConfigs[i].TargetLabel)
+		if !cfg.RelabelConfigs[i].OnlyCounter {
+			labels = append(labels, cfg.RelabelConfigs[i].TargetLabel)
+		}
+		counterLabels = append(counterLabels, cfg.RelabelConfigs[i].TargetLabel)
 	}
 
 	for _, r := range relabeling.DefaultRelabelings {
 		if !inLabels(r.TargetLabel, labels) {
 			labels = append(labels, r.TargetLabel)
+		}
+		if !inLabels(r.TargetLabel, counterLabels) {
+			counterLabels = append(counterLabels, r.TargetLabel)
 		}
 	}
 
@@ -103,7 +110,7 @@ func (m *Metrics) Init(cfg *config.NamespaceConfig) {
 		ConstLabels: cfg.NamespaceLabels,
 		Name:        "http_response_count_total",
 		Help:        "Amount of processed HTTP requests",
-	}, labels)
+	}, counterLabels)
 
 	m.bytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   cfg.NamespacePrefix,
@@ -356,20 +363,22 @@ func processSource(nsCfg config.NamespaceConfig, t tail.Follower, parser *gonx.P
 			}
 		}
 
+		notCounterValues := relabeling.StripOnlyCounterValues(labelValues, relabelings)
+
 		metrics.countTotal.WithLabelValues(labelValues...).Inc()
 
 		if bytes, ok := floatFromFields(fields, "body_bytes_sent"); ok {
-			metrics.bytesTotal.WithLabelValues(labelValues...).Add(bytes)
+			metrics.bytesTotal.WithLabelValues(notCounterValues...).Add(bytes)
 		}
 
 		if upstreamTime, ok := floatFromFields(fields, "upstream_response_time"); ok {
-			metrics.upstreamSeconds.WithLabelValues(labelValues...).Observe(upstreamTime)
-			metrics.upstreamSecondsHist.WithLabelValues(labelValues...).Observe(upstreamTime)
+			metrics.upstreamSeconds.WithLabelValues(notCounterValues...).Observe(upstreamTime)
+			metrics.upstreamSecondsHist.WithLabelValues(notCounterValues...).Observe(upstreamTime)
 		}
 
 		if responseTime, ok := floatFromFields(fields, "request_time"); ok {
-			metrics.responseSeconds.WithLabelValues(labelValues...).Observe(responseTime)
-			metrics.responseSecondsHist.WithLabelValues(labelValues...).Observe(responseTime)
+			metrics.responseSeconds.WithLabelValues(notCounterValues...).Observe(responseTime)
+			metrics.responseSecondsHist.WithLabelValues(notCounterValues...).Observe(responseTime)
 		}
 	}
 }

--- a/relabeling/types.go
+++ b/relabeling/types.go
@@ -38,3 +38,17 @@ func UniqueRelabelings(relabelings []*Relabeling) []*Relabeling {
 	}
 	return result
 }
+
+// StripOnlyCounterValues strips all values that are associated to relabelings only intended for the request counter
+func StripOnlyCounterValues(values []string, relabelings []*Relabeling) []string {
+	result := make([]string, 0, len(values))
+	offset := len(values) - len(relabelings)
+	for i := range values {
+		if i >= offset && relabelings[i-offset].OnlyCounter {
+			// skip if relabeling and only enabled for counter
+			continue
+		}
+		result = append(result, values[i])
+	}
+	return result
+}


### PR DESCRIPTION
Dynamic relabeling can potentially result in a lot of time series being
collected, especially related to the response and upstreams time
histograms.
This change is intended to allow collecting more detailed information on
response count without the side effect of adding more dimensions to the
other metrics.

See also https://github.com/martin-helmich/prometheus-nginxlog-exporter/pull/128